### PR TITLE
[BluePrint\Utils] Change root namespace & FQCN

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ composer require yannoff/lumiere
 
 ## Reference
 
-### [Database\BluePrint\Utils](/src/Database/BluePrint/Utils.php)::addTimestamps()
+### [Utils\Database\BluePrintUtils](/src/Database/BluePrintUtils.php)::addTimestamps()
 
 #### Synopsis
 
 ```php
-Utils::addTimestamps(Blueprint $table, int $precision = 0)
+BluePrintUtils::addTimestamps(Blueprint $table, int $precision = 0)
 ```
 > Add `created_at` & `updated_at` columns with `DEFAULT CURRENT_TIMESTAMP` to the blueprint
 
@@ -26,7 +26,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-use Yannoff\Lumiere\Database\BluePrint\Utils;
+use Yannoff\Lumiere\Utils\Database\BluePrintUtils;
 
 class CreateTagsTable extends Migration
 {
@@ -39,7 +39,7 @@ class CreateTagsTable extends Migration
             $table->id();
             $table->string('label', 120);
             $table->string('slug', 128);
-            Utils::addTimestamps($table);
+            BluePrintUtils::addTimestamps($table);
         });
     }
 }

--- a/UPGRADE-0.2.md
+++ b/UPGRADE-0.2.md
@@ -1,0 +1,8 @@
+# Version 0.2 upgrade notes
+
+## Deprecations
+
+- The `Database\BluePrint\Utils` class as been moved to `Utils\Database\BluePrintUtils`
+
+> The old FQCN is deprecated as of version `0.2` and support will be removed in version `1.0` .
+

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }],
     "autoload": {
         "psr-4": {
-            "Yannoff\\Lumiere\\": "src/"
+            "Yannoff\\Lumiere\\Utils\\": "src/",
+            "Yannoff\\Lumiere\\Database\\": "lib/Database/"
         }
     },
     "minimum-stability": "dev",

--- a/lib/Database/BluePrint/Utils.php
+++ b/lib/Database/BluePrint/Utils.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the yannoff/lumiere library
+ *
+ * (c) Yannoff (https://github.com/yannoff)
+ *
+ * For the full copyright and license information,
+ * please view the LICENSE file bundled with this
+ * source code.
+ */
+
+namespace Yannoff\Lumiere\Database\BluePrint;
+
+use Yannoff\Lumiere\Utils\Database\BluePrintUtils;
+
+/**
+ * The only purpose of this file is to provide BC support for versions < 0.2
+ * while raising an explicit deprecation warning suitable for logging, depending
+ * on the laravel application's configured log level
+ */
+trigger_error(
+    sprintf(
+        'Class "%s\Utils" is deprecated and will be removed in version 1.0, use "%s" instead',
+        __NAMESPACE__,
+        BluePrintUtils::class
+    ),
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since version 0.2.0, will be removed in version 1.x
+ */
+class Utils extends BluePrintUtils
+{
+}

--- a/src/Database/BluePrintUtils.php
+++ b/src/Database/BluePrintUtils.php
@@ -9,15 +9,15 @@
  * source code.
  */
 
-namespace Yannoff\Lumiere\Database\BluePrint;
+namespace Yannoff\Lumiere\Utils\Database;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Database utilities class
+ * BluePrintUtils utilities class
  */
-class Utils
+class BluePrintUtils
 {
     /**
      * Add "created_at" and "updated_at" columns with DEFAULT CURRENT_TIMESTAMP to the blueprint


### PR DESCRIPTION
- Move: `Database\BluePrint\Utils` => `Utils\Database\BluePrintUtils`
- Add BC support & deprecation warning for `Database\BluePrint\Utils`